### PR TITLE
Avoid generating redundant constraints

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,5 @@
  (name ppx_make)
  (synopsis "Ppxlib based make deriver")
  (depends
-  (dune (>= 2.7.0))
   (ppxlib (>= 0.10.0))
   (ounit2 :with-test)))


### PR DESCRIPTION
Dune already adds the correct dune constraint